### PR TITLE
Working inference on a RTX4070

### DIFF
--- a/infinity/models/fused_op.py
+++ b/infinity/models/fused_op.py
@@ -7,21 +7,24 @@ from torch import nn as nn
 from torch.nn import functional as F
 
 
-@torch.compile(fullgraph=True)
+#@torch.compile(fullgraph=True)
 def fused_rms_norm(x: torch.Tensor, weight: nn.Parameter, eps: float):
-    x = x.float()
-    return (x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True).add_(eps))) * weight
+    dtype = x.dtype
+    x = (x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True).add_(eps))) * weight
+    return x.to(dtype=dtype)
 
 
-@torch.compile(fullgraph=True)
+#@torch.compile(fullgraph=True)
 def fused_ada_layer_norm(C: int, eps: float, x: torch.Tensor, scale: torch.Tensor, shift: torch.Tensor):
-    x = x.float()
+    dtype = x.dtype
     x = F.layer_norm(input=x, normalized_shape=(C,), weight=None, bias=None, eps=eps)
-    return x.mul(scale.add(1)).add_(shift)
+    x = x.mul(scale.add(1)).add_(shift)
+    return x.to(dtype=dtype)
 
 
-@torch.compile(fullgraph=True)
+#@torch.compile(fullgraph=True)
 def fused_ada_rms_norm(C: int, eps: float, x: torch.Tensor, scale: torch.Tensor, shift: torch.Tensor):
-    x = x.float()
+    dtype = x.dtype
     x = (x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True).add_(eps)))
-    return x.mul(scale.add(1)).add_(shift)
+    x = x.mul(scale.add(1)).add_(shift)
+    return x.to(dtype=dtype)

--- a/scripts/infer.sh
+++ b/scripts/infer.sh
@@ -8,7 +8,7 @@ use_bit_label=1
 checkpoint_type='torch'
 infinity_model_path=weights/infinity_2b_reg.pth
 vae_type=32
-vae_path=weights/infinity_vae_d32_reg.pth
+vae_path=weights/infinity_vae_d32reg.pth
 cfg=4
 tau=0.5
 rope2d_normalized_by_hw=2
@@ -22,6 +22,7 @@ apply_spatial_patchify=0
 python3 tools/run_infinity.py \
 --cfg ${cfg} \
 --tau ${tau} \
+--bf16 1 \
 --pn ${pn} \
 --model_path ${infinity_model_path} \
 --vae_type ${vae_type} \
@@ -38,6 +39,6 @@ python3 tools/run_infinity.py \
 --text_encoder_ckpt ${text_encoder_ckpt} \
 --text_channels ${text_channels} \
 --apply_spatial_patchify ${apply_spatial_patchify} \
---prompt "a beautifual Chinese woman in her late 30s, wearing a suit and tie, looking at the camera" \
+--prompt "a tornado made out of cake in the style of mad max" \
 --seed 1 \
 --save_file tmp.jpg


### PR DESCRIPTION
It is possible to run inference under 12GB VRAM with those modifications. It's not really fast as you need to swap the transformer to cpu, then text_encoder to gpu, etc. I also had to remove the torch.compile directives due to the precision being bfloat16 everywhere.

![image](https://github.com/user-attachments/assets/805a01f0-c844-4e21-b41d-bd0247becff6)
